### PR TITLE
allow fragments to determine a custom loader id

### DIFF
--- a/library/src/main/java/com/propaneapps/tomorrow/base/BasePresenterActivity.java
+++ b/library/src/main/java/com/propaneapps/tomorrow/base/BasePresenterActivity.java
@@ -38,8 +38,12 @@ public abstract class BasePresenterActivity<V, P extends Presenter<V>> extends A
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        new LoaderBridge<P>(this, getSupportLoaderManager(), DEFAULT_BASE_LOADER_ID)
+        new LoaderBridge<P>(this, getSupportLoaderManager(), getLoaderId())
                 .retrievePresenter(savedInstanceState, getPresenterFactory(), this);
+    }
+
+    protected int getLoaderId() {
+        return DEFAULT_BASE_LOADER_ID;
     }
 
     public abstract FactoryWithType<P> getPresenterFactory();

--- a/library/src/main/java/com/propaneapps/tomorrow/base/BasePresenterFragment.java
+++ b/library/src/main/java/com/propaneapps/tomorrow/base/BasePresenterFragment.java
@@ -40,8 +40,12 @@ public abstract class BasePresenterFragment<V, P extends Presenter<? super V>> e
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        new LoaderBridge<P>(getActivity(), getLoaderManager(), DEFAULT_BASE_LOADER_ID)
+        new LoaderBridge<P>(getActivity(), getLoaderManager(), getLoaderId())
                 .retrievePresenter(savedInstanceState, getPresenterFactory(), this);
+    }
+
+    protected int getLoaderId() {
+        return DEFAULT_BASE_LOADER_ID;
     }
 
     public abstract FactoryWithType<P> getPresenterFactory();


### PR DESCRIPTION
hi! great to see some work like your library. however, in a situation with a viewpager and several fragments, I run into the situation where fragments are re-associated with the wrong presenter:

```
java.lang.IllegalStateException: Loader presenter not of expected type
    at com.propaneapps.tomorrow.loader.LoaderBridge.retrievePresenterFromExistingLoaderAndInformListener(LoaderBridge.java:104)
    at com.propaneapps.tomorrow.loader.LoaderBridge.retrievePresenter(LoaderBridge.java:67)
    at com.propaneapps.tomorrow.base.BasePresenterFragment.onActivityCreated(BasePresenterFragment.java:43)
    at android.support.v4.app.Fragment.performActivityCreated(Fragment.java:1983)
    at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1092)
    at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1252)
    at android.support.v4.app.BackStackRecord.run(BackStackRecord.java:742)
    at android.support.v4.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1617)
    at android.support.v4.app.FragmentManagerImpl.executePendingTransactions(FragmentManager.java:570)
    at android.support.v4.app.FragmentStatePagerAdapter.finishUpdate(FragmentStatePagerAdapter.java:164)
    at android.support.v4.view.ViewPager.populate(ViewPager.java:1177)
    at android.support.v4.view.ViewPager.populate(ViewPager.java:1025)
    at android.support.v4.view.ViewPager.onMeasure(ViewPager.java:1545)
    at android.view.View.measure(View.java:18794)
    ...
```

so here you go, this PR gives fragments some flexibility in setting IDs in a way that there won't be collisions. the default behavior is not changed
